### PR TITLE
Changes required for using 0.4.88

### DIFF
--- a/src/FooUser/FooUser.csproj
+++ b/src/FooUser/FooUser.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net462</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Walkthrough.Foo/Walkthrough.Foo.csproj
+++ b/src/Walkthrough.Foo/Walkthrough.Foo.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net462</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CodeGeneration.Roslyn.BuildTime" Version="0.4.11" PrivateAssets="All" />
+    <PackageReference Include="CodeGeneration.Roslyn.BuildTime" Version="0.4.88" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Walkthrough.Generators\Walkthrough.Generators.csproj" />
-    <DotNetCliToolReference Include="dotnet-codegen" Version="0.4.11" />
+    <DotNetCliToolReference Include="dotnet-codegen" Version="0.4.88" />
   </ItemGroup>
 
 </Project>

--- a/src/Walkthrough.Generators/DuplicateWithSuffixGenerator.cs
+++ b/src/Walkthrough.Generators/DuplicateWithSuffixGenerator.cs
@@ -23,7 +23,7 @@ public class DuplicateWithSuffixGenerator : ICodeGenerator
         var results = SyntaxFactory.List<MemberDeclarationSyntax>();
 
         // Our generator is applied to any class that our attribute is applied to.
-        var applyToClass = (ClassDeclarationSyntax)context.ProcessingMember;
+        var applyToClass = (ClassDeclarationSyntax)context.ProcessingNode;
 
         // Apply a suffix to the name of a copy of the class.
         var copy = applyToClass

--- a/src/Walkthrough.Generators/Walkthrough.Generators.csproj
+++ b/src/Walkthrough.Generators/Walkthrough.Generators.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net462</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CodeGeneration.Roslyn" Version="0.4.11" PrivateAssets="all" />
+    <PackageReference Include="CodeGeneration.Roslyn" Version="0.4.88" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -2,6 +2,5 @@
 <configuration>
   <packageSources>
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="corefxlab" value="https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
* CodeGeneration.Roslyn packages updated 0.4.11->0.4.88
* One update of breaking change (`ProcessingMember` -> `ProcessingNode`)
* Updated target frameworks to netstandard1.6 (was 1.5)
* Also removed additional `corefxlab` NuGet source as the CommandLine stuff was internalized